### PR TITLE
Disallow installation on Python 2.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,3 +141,4 @@ Contributors
 - Konstantin Stadler (issues & use in IOA)
 - Dhanuka Lakshan
 - Andreas Fehlner
+- Elliott Sales de Andrade

--- a/flit.ini
+++ b/flit.ini
@@ -4,6 +4,7 @@ author = Rick Lupton
 author-email = rick.lupton@eng.cam.ac.uk
 home-page = https://github.com/ricklupton/floweaver
 classifiers = License :: OSI Approved :: MIT License
+requires-python = ">=3.4"
 requires = numpy
         pandas
         networkx (>=1,<2)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[bdist_wheel]
-# This flag says to generate wheels that support both Python 2 and Python
-# 3. If your code will not run unchanged on both Python 2 and 3, you will
-# need to generate separate wheels for each Python version that you
-# support.
-universal=1

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,22 @@
 import codecs
 import re
 from os import path
+import sys
 
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
 
 here = path.abspath(path.dirname(__file__))
+
+# This check is here if the user does not have a new enough pip to recognize
+# the minimum Python requirement in the metadata.
+if sys.version_info < (3, 4):
+    error = """
+floWeaver 2.0.0+ does not support Python 2.x, 3.0, 3.1, 3.2, or 3.3.
+Python 3.4 and above is required. This may be due to an out of date pip.
+Make sure you have pip >= 9.0.1.
+"""
+    sys.exit(error)
 
 
 def read(*parts):
@@ -46,6 +57,7 @@ setup(
     ],
     keywords='Sankey diagram flow data visualisation',
     packages=find_packages(exclude=['docs', 'tests']),
+    python_requires='>=3.4',
     install_requires=[
         'numpy',
         'pandas',


### PR DESCRIPTION
This takes advantage of package metadata to require Python 3.4. If a new enough pip that doesn't understand the metadata is being used, then setup.py also checks for outdated Python.

Fixes #23.