### PR TITLE
add linkLabelFormat & linkLabelMinWidth arguments

### DIFF
--- a/floweaver/sankey_data.py
+++ b/floweaver/sankey_data.py
@@ -58,8 +58,8 @@ class SankeyData(object):
                 json.dump(data, f)
 
     def to_widget(self, width=700, height=500, margins=None,
-                  align_link_types=False, linkLabelFormat='', 
-                  linkLabelMinWidth=5, debugging=False):
+                  align_link_types=False, link_label_format='', 
+                  link_label_min_width=5, debugging=False):
 
         if SankeyWidget is None:
             raise RuntimeError('ipysankeywidget is required')
@@ -78,8 +78,8 @@ class SankeyData(object):
                               order=value['order'],
                               groups=value['groups'],
                               align_link_types=align_link_types,
-                              linkLabelFormat=linkLabelFormat,
-                              linkLabelMinWidth=linkLabelMinWidth,
+                              linkLabelFormat=link_label_format,
+                              linkLabelMinWidth=link_label_min_width,
                               layout=Layout(width=str(width), height=str(height)),
                               margins=margins)
 

--- a/floweaver/sankey_data.py
+++ b/floweaver/sankey_data.py
@@ -58,7 +58,8 @@ class SankeyData(object):
                 json.dump(data, f)
 
     def to_widget(self, width=700, height=500, margins=None,
-                  align_link_types=False, debugging=False):
+                  align_link_types=False, linkLabelFormat='', 
+                  linkLabelMinWidth=5, debugging=False):
 
         if SankeyWidget is None:
             raise RuntimeError('ipysankeywidget is required')
@@ -77,6 +78,8 @@ class SankeyData(object):
                               order=value['order'],
                               groups=value['groups'],
                               align_link_types=align_link_types,
+                              linkLabelFormat=linkLabelFormat,
+                              linkLabelMinWidth=linkLabelMinWidth,
                               layout=Layout(width=str(width), height=str(height)),
                               margins=margins)
 


### PR DESCRIPTION
with default values from https://github.com/ricklupton/ipysankeywidget/blob/ff72925bf94bbf31ce7c791be53363e669f04a75/js/lib/sankey-widget.js#L47-L48 
can be passed when using the to_widget method.
solving issue 74: https://github.com/ricklupton/floweaver/issues/74