### PR TITLE
Fix widget JSON when measure is not "value"

### DIFF
--- a/floweaver/sankey_data.py
+++ b/floweaver/sankey_data.py
@@ -177,6 +177,7 @@ class SankeyLink(object):
     target = attr.ib(validator=attr.validators.optional(attr.validators.instance_of(str)))
     type = attr.ib(default=None, validator=_validate_opt_str)
     time = attr.ib(default=None, validator=_validate_opt_str)
+    link_width = attr.ib(default=0.0, converter=float)
     data = attr.ib(default=lambda: {"value": 0.0})
     title = attr.ib(default=None, validator=_validate_opt_str)
     color = attr.ib(default=None, validator=_validate_opt_str)
@@ -191,7 +192,7 @@ class SankeyLink(object):
                 "target": self.target,
                 "type": self.type,
                 "time": self.time,
-                "value": self.data["value"],
+                "value": self.link_width,
                 "title": self.title,
                 "color": self.color,
                 "opacity": self.opacity,
@@ -204,6 +205,7 @@ class SankeyLink(object):
                 "type": self.type,
                 "title": self.title,
                 "time": self.time,
+                "link_width": self.link_width,
                 "data": self.data,
                 "style": {"color": self.color, "opacity": self.opacity,},
             }

--- a/floweaver/weave.py
+++ b/floweaver/weave.py
@@ -115,7 +115,7 @@ def make_link(get_value, get_color, v, w, m, t, data):
     )
     return attr.evolve(
         link,
-        # value=get_value(link, data['measures']),
+        link_width=get_value(link, data['measures']),
         color=get_color(link, data["measures"]),
     )
 

--- a/test/test_sankey_data.py
+++ b/test/test_sankey_data.py
@@ -57,8 +57,8 @@ def test_sankey_data_link_default_values():
 
 
 def test_sankey_data_link_json():
-    link = SankeyLink('a', 'b', type='c', time='d', data={'value': 2}, title='link',
-                      opacity=0.9, color='blue')
+    link = SankeyLink('a', 'b', type='c', time='d', data={'value': 2},
+                      link_width=3, title='link', opacity=0.9, color='blue')
 
     # draft JSON Sankey serialisation format
     assert link.to_json() == {
@@ -66,6 +66,7 @@ def test_sankey_data_link_json():
         'target': 'b',
         'type': 'c',
         'time': 'd',
+        'link_width': 3,
         'data': {
             'value': 2,
         },
@@ -82,7 +83,7 @@ def test_sankey_data_link_json():
         'target': 'b',
         'type': 'c',
         'time': 'd',
-        'value': 2,
+        'value': 3,
         'data': {
             'value': 2,
         },

--- a/test/test_weave.py
+++ b/test/test_weave.py
@@ -60,7 +60,8 @@ def test_weave_results():
 
     def link(src, tgt, original_flows, value, link_type='*', color='#FBB4AE'):
         return SankeyLink(source=src, target=tgt, type=link_type, time='*',
-                          data={'value': value}, title=link_type, color=color,
+                          link_width=value, data={'value': value},
+                          title=link_type, color=color,
                           original_flows=original_flows)
 
     assert set(n.id for n in result.nodes) == {'a^*', 'b^*', 'via^m', 'via^n', 'c^c1', 'c^c2'}


### PR DESCRIPTION
Previous change 14aa45beb48ac475d155c0ea9f0a222a9ccf6183 was incomplete, but it happened to work when there was still a measure called "value" defined (which is what happens by default).