### PR TITLE
docs: update copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Rick Lupton
+Copyright (c) 2023 Rick Lupton
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'floWeaver'
-copyright = '2017, Rick Lupton'
+copyright = '2023, Rick Lupton & Contributors'
 author = 'Rick Lupton'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
+ bump copyright year in license

Thought it would be nice to have a newer date in the docs footer, and why not acknowledge contributors as well!